### PR TITLE
Update deployproxy.js

### DIFF
--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -719,6 +719,15 @@ function deployProxy(opts, request, done) {
     }, function(err, req, body) {
       if (err) { return done(err); }
 
+      // sometimes the body isn't json, sometimes, when things go wrong, it's xml
+      if ((body) && (body.trim.startsWith('<'))) {
+        // not json, maybe xml - assuming it's an error 
+        if (opts.verbose) { 
+          console.log('Deployment on %s failed with statusCode: %d\nresponse:\n %s', 
+                      environment, req.statusCode, body); 
+        }
+        return done(new Error(body));
+      }
       var jsonBody = (body ? JSON.parse(body) : null);
 
       if (req.statusCode === 200) {


### PR DESCRIPTION
fixing this error ...
SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at Request._callback (/usr/local/lib/node_modules/apigeetool/lib/commands/deployproxy.js:722:35)